### PR TITLE
fix(ArticleForm): Fix file uploader

### DIFF
--- a/src/components/ArticleForm.js
+++ b/src/components/ArticleForm.js
@@ -8,9 +8,13 @@ import {
   Input,
   TextArea,
   FileInput,
+  SubmitForm,
+  ErrorMessage,
+  SuccessMessage,
 } from '../styles/FormStyles';
 import { useState, useCallback, useEffect } from 'react';
 import { binaryStringToBytesArray } from '../utils';
+import { Link } from 'react-router-dom';
 import { MyButton } from './Button';
 import { logger } from '../utils/logger';
 import {
@@ -77,7 +81,6 @@ const ArticleForm = ({ formTitle, onSubmit, action, article }) => {
           }
         }
       }
-      // logger.debug("content in useEffect",String.fromCharCode(...article.file.content.data))
       setFile(article.file);
       setIsSet(true);
     }
@@ -122,7 +125,6 @@ const ArticleForm = ({ formTitle, onSubmit, action, article }) => {
       setTitleError('');
     }
   };
-  // let decoder = new TextDecoder("utf-8");
   const handleFileChange = useCallback(
     (e) => {
       const fileInput = e.target.files[0];
@@ -130,23 +132,19 @@ const ArticleForm = ({ formTitle, onSubmit, action, article }) => {
       setFile(fileInput);
       setFileName(fileInput.name);
       setType(fileInput.type);
-      // logger.debug('filename',fileInput.name)
-      // logger.debug('type',fileInput.type)
-      // logger.debug("Input File",fileInput)
       const reader = new FileReader();
       reader.onload = (event) => {
         const fileContent = event.target.result;
-        logger.debug(fileContent);
-        // const trick = await fetch(`data:${type};base64,${fileContent}`)
-        // const blob = await trick.blob()
-        // const imgUrl = URL.createObjectURL(blob)
-        setSrcImg(fileContent);
-        logger.debug('file content on input change:', fileContent);
 
-        // logger.debug("File Content",fileContent)
-        // let decodedContent = decoder.decode(fileContent);
-        // let        encoder = new TextEncoder()
-        // let        encoded =encoder.encode(fileContent)
+        // Lire en DataURL pour la prévisualisation
+        const readerPreview = new FileReader();
+        readerPreview.onload = (e) => setSrcImg(e.target.result);
+        readerPreview.readAsDataURL(fileInput);
+
+        // Lire en BinaryString pour l'envoi en binary au serveur
+        const readerBinary = new FileReader();
+        readerBinary.readAsBinaryString(fileInput);
+        logger.debug(fileContent);
         let encoded = btoa(fileContent);
         logger.debug('file content before encoding', fileContent);
         logger.debug('encoded data', encoded);
@@ -155,7 +153,6 @@ const ArticleForm = ({ formTitle, onSubmit, action, article }) => {
         setRawData(binaryStringToBytesArray(fileContent));
         logger.debug('rawData:', rawData);
       };
-      reader.readAsDataURL(fileInput);
     },
     [rawData],
   );
@@ -235,6 +232,7 @@ const ArticleForm = ({ formTitle, onSubmit, action, article }) => {
               <Label>Image actuelle :</Label>
               <DynamicItemImageComponent
                 apiUrl={`${apiBaseUrl}/api/articleImage/${article._id}`}
+                setContent={setContent}
               />
             </>
           )}

--- a/src/components/DynamicImageComponent.js
+++ b/src/components/DynamicImageComponent.js
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { ImageContainer, StyledImage } from "../styles/ImageStyles";
-import Loader from "./Loader";
+import React, { useCallback, useEffect, useState } from 'react';
+import { ImageContainer, StyledImage } from '../styles/ImageStyles';
+import Loader from './Loader';
 
 export const DynamicImageComponent = ({ src, alt }) => {
   return (
@@ -10,37 +10,38 @@ export const DynamicImageComponent = ({ src, alt }) => {
   );
 };
 
-export const DynamicItemImageComponent = ({ apiUrl }) => {
-    const [srcImg, setSrcImg] = useState(null);
-    const [altLabel, setAltLabel] = useState(null);
+export const DynamicItemImageComponent = ({ apiUrl, setContent = null }) => {
+  const [srcImg, setSrcImg] = useState(null);
+  const [altLabel, setAltLabel] = useState(null);
 
-    const fetchImages = useCallback( async () => {
-        const res = await fetch(apiUrl);
-        const data = await res.json();
-      // this is a trick to convert a base64 encoded string into a blob
-      // using the fetch API for local resources 
-        const base64Response = await fetch(
-        `data:${data.mimeType};base64,${data.content}`
-        );
-        const blob = await base64Response.blob();
-        const dataURL = URL.createObjectURL(blob);
-        setSrcImg(dataURL);
-        setAltLabel(data.label)
-    }
-        , [apiUrl])
-
-    useEffect(() => {
-        fetchImages();
-    }, [fetchImages]);
-  
-    return (
-
-        <ImageContainer>
-            { srcImg ? (
-                <StyledImage src={srcImg} alt={altLabel} />
-            ) : (
-                <Loader label={'Loading Image...'}/> 
-            )}
-        </ImageContainer>
+  const fetchImages = useCallback(async () => {
+    const res = await fetch(apiUrl);
+    const data = await res.json();
+    // this is a trick to convert a base64 encoded string into a blob
+    // using the fetch API for local resources
+    const base64Response = await fetch(
+      `data:${data.mimeType};base64,${data.content}`,
     );
+    const blob = await base64Response.blob();
+    const dataURL = URL.createObjectURL(blob);
+    setSrcImg(dataURL);
+    setAltLabel(data.label);
+    if (setContent) {
+      setContent(data.content);
+    }
+  }, [apiUrl, setContent]);
+
+  useEffect(() => {
+    fetchImages();
+  }, [fetchImages]);
+
+  return (
+    <ImageContainer>
+      {srcImg ? (
+        <StyledImage src={srcImg} alt={altLabel} />
+      ) : (
+        <Loader label={'Loading Image...'} />
+      )}
+    </ImageContainer>
+  );
 };


### PR DESCRIPTION
### Previous Bugs:
1. When previewing a file we did not set the content of the input to the right content so the file if not changed was lost.
2. When uploading a file we could not have the preview cause we did not use both JS API Reader one for the prevew and the other one to send the binary content to the server.

### Fix:
1. Set the content using the `DynamicItemImageContainer` and passing a new optional `setContent` attribute as it already do the job of retrieving content.
2. use a logic with both reader for the preview and for the content as binary
 